### PR TITLE
simulation with workspace

### DIFF
--- a/src/mlmc/sampling_pool.py
+++ b/src/mlmc/sampling_pool.py
@@ -6,7 +6,7 @@ import numpy as np
 from typing import List
 from abc import ABC, abstractmethod
 from multiprocessing import Pool as ProcPool
-from multiprocessing.pool import ThreadPool as Threads
+from multiprocessing import pool
 from level_simulation import LevelSimulation
 
 
@@ -187,6 +187,9 @@ class OneProcessPool(SamplingPool):
 
 
 class ProcessPool(OneProcessPool):
+    """
+    Suitable for local parallel sampling for simulations WITHOUT external program call
+    """
 
     def __init__(self, n_processes, work_dir=None):
         self._pool = ProcPool(n_processes)
@@ -211,9 +214,12 @@ class ProcessPool(OneProcessPool):
 
 
 class ThreadPool(ProcessPool):
+    """
+    Suitable local parallel sampling for simulations WITH external program call
+    """
 
     def __init__(self, n_thread, work_dir=False):
-        self._pool = Threads(n_thread)
+        self._pool = pool.ThreadPool(n_thread)
         self._work_dir = work_dir
         self._failed_queues = {}
         self._queues = {}

--- a/test/synth_simulation_workspace.py
+++ b/test/synth_simulation_workspace.py
@@ -1,16 +1,21 @@
+import os
+import yaml
 import numpy as np
 from typing import List
+from scipy import stats
 from new_simulation import Simulation
 from level_simulation import LevelSimulation
 from new_simulation import QuantitySpec
 
 
-class SynthSimulation(Simulation):
+class SynthSimulationWorkspace(Simulation):
 
     n_nans = 0
     nan_fraction = 0
     len_results = 0
     result_dict = {}
+
+    CONFIG_FILE = 'synth_sim_config.yaml'
 
     # Artificial simulation. Just random parameter + numerical error."""
     def __init__(self, config):
@@ -22,12 +27,14 @@ class SynthSimulation(Simulation):
                 sim_method=used method for calculating sample result
         """
         super().__init__(config)
-        self.config = config
-        SynthSimulation.n_nans = 0
-        SynthSimulation.nan_fraction = config.get('nan_fraction', 0.0)
-        SynthSimulation.len_results = 0
+        self.config_yaml = config["config_yaml"]
+
+        SynthSimulationWorkspace.n_nans = 0
+        SynthSimulationWorkspace.nan_fraction = config.get('nan_fraction', 0.0)
+        SynthSimulationWorkspace.len_results = 0
+
         # This attribute is obligatory
-        self.need_workspace: bool = False
+        self.need_workspace: bool = True
 
     @staticmethod
     def sample_fn(x, h):
@@ -60,11 +67,14 @@ class SynthSimulation(Simulation):
         config = dict()
         config["fine"] = {}
         config["coarse"] = {}
+
         config["fine"]["step"] = fine_level_params[0]
         config["coarse"]["step"] = coarse_level_params[0]
-        config["distr"] = self.config["distr"]
 
-        return LevelSimulation(config_dict=config, task_size=self.n_ops_estimate(fine_level_params[0]))
+        return LevelSimulation(config_dict=config,
+                               common_files=[self.config_yaml],
+                               task_size=self.n_ops_estimate(fine_level_params[0]),
+                               need_sample_workspace=self.need_workspace)
 
     @staticmethod
     def generate_random_samples(distr, seed):
@@ -74,12 +84,18 @@ class SynthSimulation(Simulation):
         :param seed: uint32
         :return: fine sample, coarse sample
         """
-        SynthSimulation.len_results += 1
+        SynthSimulationWorkspace.len_results += 1
+
+        if distr == "norm":
+            distr = stats.norm(loc=1, scale=2)
+        else:
+            raise NotImplementedError("Other distributions are not implemented yet")
+
         distr.random_state = np.random.RandomState(seed)
         y = distr.rvs(size=1)
 
-        if SynthSimulation.n_nans / (1e-10 + SynthSimulation.len_results) < SynthSimulation.nan_fraction:
-            SynthSimulation.n_nans += 1
+        if SynthSimulationWorkspace.n_nans / (1e-10 + SynthSimulationWorkspace.len_results) < SynthSimulationWorkspace.nan_fraction:
+            SynthSimulationWorkspace.n_nans += 1
             y = [np.nan]
 
         return y, y
@@ -91,17 +107,20 @@ class SynthSimulation(Simulation):
         :param config: dictionary containing simulation configuration
         :return:
         """
-        fine_random, coarse_random = SynthSimulation.generate_random_samples(config["distr"], seed)
+        config_file = SynthSimulationWorkspace._read_config()
+        SynthSimulationWorkspace.nan_fraction = config_file["nan_fraction"]
+
+        fine_random, coarse_random = SynthSimulationWorkspace.generate_random_samples(config_file["distr"], seed)
 
         fine_step = config["fine"]["step"]
         coarse_step = config["coarse"]["step"]
 
-        fine_result = SynthSimulation.sample_fn(fine_random, fine_step)
+        fine_result = SynthSimulationWorkspace.sample_fn(fine_random, fine_step)
 
         if coarse_step == 0:
             coarse_result = np.zeros(len(fine_result))
         else:
-            coarse_result = SynthSimulation.sample_fn(coarse_random, coarse_step)
+            coarse_result = SynthSimulationWorkspace.sample_fn(coarse_random, coarse_step)
 
         if np.isnan(fine_result) or np.isnan(coarse_result):
             raise Exception("result is nan")
@@ -109,7 +128,15 @@ class SynthSimulation(Simulation):
         return fine_result, coarse_result
 
     def n_ops_estimate(self, step):
-        return (1 / step) ** self.config['complexity'] * np.log(max(1 / step, 2.0))
+        # @TODO: how to determine n ops
+        return (1 / step) ** 2 * np.log(max(1 / step, 2.0))
+
+    @staticmethod
+    def _read_config():
+        with open(os.path.join(os.getcwd(), SynthSimulationWorkspace.CONFIG_FILE)) as file:
+            config = yaml.load(file)
+
+        return config
 
     # @staticmethod
     # def result_format() -> List[QuantitySpec]:

--- a/test/test_sampler_multiproc.py
+++ b/test/test_sampler_multiproc.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import numpy as np
 import shutil
 from scipy import stats
 
@@ -11,22 +12,18 @@ from sample_storage import Memory
 from sampling_pool import ProcessPool, ThreadPool, OneProcessPool
 from mlmc.moments import Legendre
 
-def multiproces_sampler_test(hdf=False):
 
-    n_levels = 2
-    failed_fraction = 0#0.2
+def multiproces_sampler_test():
+    np.random.seed(3)
+    n_moments = 5
 
-    work_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '_test_tmp')
-    if os.path.exists(work_dir):
-        shutil.rmtree(work_dir)
-    os.makedirs(work_dir)
+    failed_fraction = 0.1
+    distr = stats.norm(loc=1, scale=2)
 
-    distr = stats.norm()
-    step_range = (0.1, 0.006)
+    step_range = [0.01]#, 0.001, 0.0001]
 
-    # User configure and create simulation instance
+    # Create simulation instance
     simulation_config = dict(distr=distr, complexity=2, nan_fraction=failed_fraction, sim_method='_sample_fn')
-    #simulation_config = {"config_yaml": 'synth_sim_config.yaml'}
     simulation_factory = SynthSimulation(simulation_config)
 
     sample_storage = Memory()
@@ -36,17 +33,29 @@ def multiproces_sampler_test(hdf=False):
     sampler = Sampler(sample_storage=sample_storage, sampling_pool=sampling_pool, sim_factory=simulation_factory,
                       step_range=step_range)
 
-    sampler.determine_level_n_samples()
+    true_domain = distr.ppf([0.0001, 0.9999])
+    moments_fn = Legendre(n_moments, true_domain)
+
+    sampler.set_initial_n_samples()
+    #sampler.set_initial_n_samples([1000])
     sampler.schedule_samples()
     sampler.ask_sampling_pool_for_samples()
 
-    # After crash
-    # sampler = Sampler(sample_storage=sample_storage, sampling_pool=sampling_pool, config=mlv)
-    # sampler.load_from_storage()
-    #
-    # This should happen automatically
-    # sampler.determine_level_n_samples()
-    # sampler.create_simulations()
+    sampler.target_var_adding_samples(1e-4, moments_fn, sleep=20)
+    print("collected samples ", sampler._n_created_samples)
+
+    means, vars = sampler.estimate_moments(moments_fn)
+
+    print("means ", means)
+    print("vars ", vars)
+    assert means[0] == 1
+    assert np.isclose(means[1], 0, atol=1e-2)
+    assert vars[0] == 0
+    sampler.schedule_samples()
+    sampler.ask_sampling_pool_for_samples()
+
+    storage = sampler.sample_storage
+    results = storage.sample_pairs()
 
 
 if __name__ == "__main__":

--- a/test/test_sampler_sim_workspace.py
+++ b/test/test_sampler_sim_workspace.py
@@ -1,0 +1,166 @@
+import os
+import sys
+import numpy as np
+import shutil
+import yaml
+from scipy import stats
+
+src_path = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(src_path, '..', 'src/mlmc'))
+from synth_simulation_workspace import SynthSimulationWorkspace
+from sampler import Sampler
+from sample_storage import Memory
+from sampling_pool import ProcessPool, ThreadPool, OneProcessPool
+from mlmc.moments import Legendre
+
+
+def oneprocess_test():
+    np.random.seed(3)
+    n_moments = 5
+
+    distr = stats.norm(loc=1, scale=2)
+    step_range = [0.01, 0.001]
+
+    # Set work dir
+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
+    work_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '_test_tmp')
+    if os.path.exists(work_dir):
+        shutil.rmtree(work_dir)
+    os.makedirs(work_dir)
+    shutil.copyfile('synth_sim_config.yaml', os.path.join(work_dir, 'synth_sim_config.yaml'))
+
+    simulation_config = {"config_yaml": os.path.join(work_dir, 'synth_sim_config.yaml')}
+    simulation_factory = SynthSimulationWorkspace(simulation_config)
+
+    sample_storage = Memory()
+    sampling_pool = OneProcessPool(work_dir=work_dir)
+
+    # Plan and compute samples
+    sampler = Sampler(sample_storage=sample_storage, sampling_pool=sampling_pool, sim_factory=simulation_factory,
+                      step_range=step_range)
+
+    true_domain = distr.ppf([0.0001, 0.9999])
+    moments_fn = Legendre(n_moments, true_domain)
+
+    sampler.set_initial_n_samples()
+    #sampler.set_initial_n_samples([1000])
+    sampler.schedule_samples()
+    sampler.ask_sampling_pool_for_samples()
+
+    sampler.target_var_adding_samples(1e-4, moments_fn, sleep=20)
+    print("collected samples ", sampler._n_created_samples)
+
+    means, vars = sampler.estimate_moments(moments_fn)
+
+    print("means ", means)
+    print("vars ", vars)
+    assert means[0] == 1
+    assert np.isclose(means[1], 0, atol=1e-2)
+    assert vars[0] == 0
+    sampler.schedule_samples()
+    sampler.ask_sampling_pool_for_samples()
+
+    storage = sampler.sample_storage
+    results = storage.sample_pairs()
+
+
+def multiprocess_test():
+    np.random.seed(3)
+    n_moments = 5
+    distr = stats.norm(loc=1, scale=2)
+    step_range = [0.01]#, 0.001, 0.0001]
+
+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
+    work_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '_test_tmp')
+    if os.path.exists(work_dir):
+        shutil.rmtree(work_dir)
+    os.makedirs(work_dir)
+    shutil.copyfile('synth_sim_config.yaml', os.path.join(work_dir, 'synth_sim_config.yaml'))
+
+    simulation_config = {"config_yaml": os.path.join(work_dir, 'synth_sim_config.yaml')}
+    simulation_factory = SynthSimulationWorkspace(simulation_config)
+
+    sample_storage = Memory()
+    sampling_pool = ProcessPool(4, work_dir=work_dir)
+
+    # Plan and compute samples
+    sampler = Sampler(sample_storage=sample_storage, sampling_pool=sampling_pool, sim_factory=simulation_factory,
+                      step_range=step_range)
+
+    true_domain = distr.ppf([0.0001, 0.9999])
+    moments_fn = Legendre(n_moments, true_domain)
+
+    sampler.set_initial_n_samples()
+    #sampler.set_initial_n_samples([1000])
+    sampler.schedule_samples()
+    sampler.ask_sampling_pool_for_samples()
+
+    sampler.target_var_adding_samples(1e-4, moments_fn, sleep=20)
+    print("collected samples ", sampler._n_created_samples)
+
+    means, vars = sampler.estimate_moments(moments_fn)
+
+    print("means ", means)
+    print("vars ", vars)
+    assert means[0] == 1
+    assert np.isclose(means[1], 0, atol=1e-2)
+    assert vars[0] == 0
+    sampler.schedule_samples()
+    sampler.ask_sampling_pool_for_samples()
+
+    storage = sampler.sample_storage
+    results = storage.sample_pairs()
+
+def thread_test():
+    np.random.seed(3)
+    n_moments = 5
+    distr = stats.norm(loc=1, scale=2)
+
+    step_range = [0.01, 0.001, 0.0001]
+
+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
+    work_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '_test_tmp')
+    if os.path.exists(work_dir):
+        shutil.rmtree(work_dir)
+    os.makedirs(work_dir)
+    shutil.copyfile('synth_sim_config.yaml', os.path.join(work_dir, 'synth_sim_config.yaml'))
+
+    simulation_config = {"config_yaml": os.path.join(work_dir, 'synth_sim_config.yaml')}
+    simulation_factory = SynthSimulationWorkspace(simulation_config)
+
+    sample_storage = Memory()
+    sampling_pool = ThreadPool(4, work_dir=work_dir)
+
+    # Plan and compute samples
+    sampler = Sampler(sample_storage=sample_storage, sampling_pool=sampling_pool, sim_factory=simulation_factory,
+                      step_range=step_range)
+
+    true_domain = distr.ppf([0.0001, 0.9999])
+    moments_fn = Legendre(n_moments, true_domain)
+
+    sampler.set_initial_n_samples()
+    # sampler.set_initial_n_samples([1000])
+    sampler.schedule_samples()
+    sampler.ask_sampling_pool_for_samples()
+
+    sampler.target_var_adding_samples(1e-4, moments_fn, sleep=20)
+    print("collected samples ", sampler._n_created_samples)
+
+    means, vars = sampler.estimate_moments(moments_fn)
+
+    print("means ", means)
+    print("vars ", vars)
+    assert means[0] == 1
+    assert np.isclose(means[1], 0, atol=1e-2)
+    assert vars[0] == 0
+    sampler.schedule_samples()
+    sampler.ask_sampling_pool_for_samples()
+
+    storage = sampler.sample_storage
+    results = storage.sample_pairs()
+
+
+if __name__ == "__main__":
+    multiprocess_test()
+    oneprocess_test()
+    thread_test()


### PR DESCRIPTION
-  no work_dir information in sampler
-  work_dir is passed directly to sampling_pool (from test file)
- sampling_pool handles sample_dir creation and it also moves failed sample dir and removes finished sample dir
- tests for multiprocess and threads, they all use simple simulation with one scalar quantity
